### PR TITLE
Apples & Pawn Energy

### DIFF
--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -23,6 +23,7 @@ namespace osg {
         private TextGameObject numGoldCoinsText;
         private TextGameObject numWoodText;
         private TextGameObject numStoneText;
+        private TextGameObject numApplesText;
 
         public GameObject playerGameObject; // must be set in Unity Editor -- TODO: make this private and set it in the constructor (will require refactoring Player.cs)
         public bool runTests = false;
@@ -52,6 +53,7 @@ namespace osg {
             numGoldCoinsText = new TextGameObject("Gold Coins: 0", 20, -Screen.width / 4, Screen.height / 4);
             numWoodText = new TextGameObject("Wood: 0", 20, -Screen.width / 4, 0);
             numStoneText = new TextGameObject("Stone: 0", 20, Screen.width / 4, 0);
+            numApplesText = new TextGameObject("Apples: 0", 20, Screen.width / 4, Screen.height / 4);
 
             environment.getChunk(0, 0).addEntity(player);
             environment.addEntityId(player.getId());
@@ -76,6 +78,7 @@ namespace osg {
                 numGoldCoinsText.updateText("Gold Coins: " + player.getInventory().getNumItems(ItemType.GOLD_COIN));
                 numWoodText.updateText("Wood: " + player.getInventory().getNumItems(ItemType.WOOD));
                 numStoneText.updateText("Stone: " + player.getInventory().getNumItems(ItemType.STONE));
+                numApplesText.updateText("Apples: " + player.getInventory().getNumItems(ItemType.APPLE));
                 status.clearStatusIfExpired();
 
                 // list of positions to generate chunks at

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -243,7 +243,16 @@ namespace osg {
         }
 
         private void computeBehaviorType(Environment environment, NationRepository nationRepository) {
-            // if leader
+            // if hungry
+            if (energy < 80 && inventory.getNumItems(ItemType.APPLE) == 0) {
+                // find nearest apple tree
+                Entity nearestTree = environment.getNearestTree(getGameObject().transform.position);
+                if (nearestTree != null) {
+                    setTargetEntity(nearestTree);
+                    currentBehaviorType = BehaviorType.GATHER_RESOURCES;
+                    return;
+                }
+            }
             if (getNationId() == null) {
                 currentBehaviorType = BehaviorType.WANDER;
                 return;
@@ -251,15 +260,6 @@ namespace osg {
             Nation nation = nationRepository.getNation(getNationId());
             NationRole role = nation.getRole(getId());
             if (role == NationRole.LEADER) {
-                if (energy < 80 && inventory.getNumItems(ItemType.APPLE) == 0) {
-                    // find nearest apple tree
-                    Entity nearestTree = environment.getNearestTree(getGameObject().transform.position);
-                    if (nearestTree != null) {
-                        setTargetEntity(nearestTree);
-                        currentBehaviorType = BehaviorType.GATHER_RESOURCES;
-                        return;
-                    }
-                }
                 currentBehaviorType = BehaviorType.WANDER;
                 return;
             }

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -12,10 +12,13 @@ namespace osg {
 
         private int targetNumWood = 3;
         private int targetNumStone = 3;
+        private int targetNumApples = 3;
         
         private int distanceThreshold = 10;
 
         private GameObject nameTag;
+        private float energy = 100.00f;
+        private float metabolism = Random.Range(0.01f, 0.05f);
 
         public Pawn(Vector3 position, string name) : base(EntityType.PAWN) {
             this.name = name;
@@ -145,6 +148,22 @@ namespace osg {
             else {
                 Debug.LogWarning("unknown behavior type in fixedUpdate(): " + currentBehaviorType);
             }
+
+            if (energy < 90 && inventory.getNumItems(ItemType.APPLE) > 0) {
+                // eat apple
+                inventory.removeItem(ItemType.APPLE, 1);
+                energy += 10;
+            }
+
+            energy -= metabolism;
+            if (energy <= 0) { // TODO: move this to OpenSourceGame.cs?
+                // respawn
+                inventory.clear();
+                energy = 100.00f;
+                getGameObject().transform.position = new Vector3(Random.Range(-100, 100), 10, Random.Range(-100, 100));
+                // TODO: throw event?
+            }
+            nameTag.GetComponent<TextMesh>().text = getName() + " (e=" + energy + ")";
         }
 
         public void setColor(Color color) {
@@ -183,6 +202,7 @@ namespace osg {
                     targetEntity.markForDeletion();
                     setTargetEntity(null);
                     inventory.addItem(ItemType.WOOD, 1);
+                    inventory.addItem(ItemType.APPLE, 1);
                 }
                 else if (targetEntity.getType() == EntityType.ROCK) {
                     targetEntity.markForDeletion();
@@ -231,6 +251,15 @@ namespace osg {
             Nation nation = nationRepository.getNation(getNationId());
             NationRole role = nation.getRole(getId());
             if (role == NationRole.LEADER) {
+                if (energy < 80 && inventory.getNumItems(ItemType.APPLE) == 0) {
+                    // find nearest apple tree
+                    Entity nearestTree = environment.getNearestTree(getGameObject().transform.position);
+                    if (nearestTree != null) {
+                        setTargetEntity(nearestTree);
+                        currentBehaviorType = BehaviorType.GATHER_RESOURCES;
+                        return;
+                    }
+                }
                 currentBehaviorType = BehaviorType.WANDER;
                 return;
             }
@@ -248,37 +277,35 @@ namespace osg {
         private void attemptToSellResourcesTo(Entity targetEntity) {
             int numWood = inventory.getNumItems(ItemType.WOOD);
             int numStone = inventory.getNumItems(ItemType.STONE);
+            int numApples = inventory.getNumItems(ItemType.APPLE);
 
+            Inventory targetInventory;
             if (targetEntity.getType() == EntityType.PAWN) {
                 Pawn targetPawn = (Pawn) targetEntity;
-
-                int cost = numWood * 2 + numStone * 3;
-                if (targetPawn.getInventory().getNumItems(ItemType.GOLD_COIN) >= cost) {
-                    targetPawn.getInventory().removeItem(ItemType.GOLD_COIN, cost);
-                    inventory.removeItem(ItemType.WOOD, numWood);
-                    inventory.removeItem(ItemType.STONE, numStone);
-                    targetPawn.getInventory().addItem(ItemType.WOOD, numWood);
-                    targetPawn.getInventory().addItem(ItemType.STONE, numStone);
-                }
-                else {
-                    setTargetEntity(null);
-                }
+                targetInventory = targetPawn.getInventory();
             }
             else if (targetEntity.getType() == EntityType.PLAYER) {
                 Player targetPlayer = (Player) targetEntity;
+                targetInventory = targetPlayer.getInventory();
+            }
+            else {
+                Debug.LogWarning("target entity is not a pawn or player");
+                setTargetEntity(null);
+                return;
+            }
 
-                int cost = numWood * 2 + numStone * 3;
-                if (targetPlayer.getInventory().getNumItems(ItemType.GOLD_COIN) >= cost) {
-                    targetPlayer.getInventory().removeItem(ItemType.GOLD_COIN, cost);
-                    inventory.removeItem(ItemType.WOOD, numWood);
-                    inventory.removeItem(ItemType.STONE, numStone);
-                    targetPlayer.getInventory().addItem(ItemType.WOOD, numWood);
-                    targetPlayer.getInventory().addItem(ItemType.STONE, numStone);
-                    targetPlayer.getStatus().update("You bought " + numWood + " wood and " + numStone + " stone from " + getName() + " for " + cost + " gold coins.");
-                }
-                else {
-                    setTargetEntity(null);
-                }
+            int cost = numWood * 2 + numStone * 3 + numApples * 1;
+            if (targetInventory.getNumItems(ItemType.GOLD_COIN) >= cost) {
+                targetInventory.removeItem(ItemType.GOLD_COIN, cost);
+                inventory.removeItem(ItemType.WOOD, numWood);
+                inventory.removeItem(ItemType.STONE, numStone);
+                inventory.removeItem(ItemType.APPLE, numApples);
+                targetInventory.addItem(ItemType.WOOD, numWood);
+                targetInventory.addItem(ItemType.STONE, numStone);
+                targetInventory.addItem(ItemType.APPLE, numApples);
+            }
+            else {
+                setTargetEntity(null);
             }
         }
     }

--- a/src/c#/main/inventory/Inventory.cs
+++ b/src/c#/main/inventory/Inventory.cs
@@ -33,7 +33,10 @@ namespace osg {
         }
 
         public void clear() {
-            items.Clear();
+            items[ItemType.GOLD_COIN] = 0;
+            items[ItemType.WOOD] = 0;
+            items[ItemType.STONE] = 0;
+            items[ItemType.APPLE] = 0;
         }
     }
 }

--- a/src/c#/main/inventory/Inventory.cs
+++ b/src/c#/main/inventory/Inventory.cs
@@ -9,6 +9,7 @@ namespace osg {
             items.Add(ItemType.GOLD_COIN, numGoldCoins);
             items.Add(ItemType.WOOD, 0);
             items.Add(ItemType.STONE, 0);
+            items.Add(ItemType.APPLE, 0);
         }
         
         public int getNumItems(ItemType itemType) {
@@ -29,6 +30,10 @@ namespace osg {
 
         public void setNumItems(ItemType itemType, int numItems) {
             items[itemType] = numItems;
+        }
+
+        public void clear() {
+            items.Clear();
         }
     }
 }

--- a/src/c#/main/item/ItemType.cs
+++ b/src/c#/main/item/ItemType.cs
@@ -2,6 +2,7 @@ namespace osg {
     public enum ItemType {
         GOLD_COIN,
         WOOD,
-        STONE
+        STONE,
+        APPLE,
     }
 }


### PR DESCRIPTION
Trees will now drop apples and pawns must replenish their energy to survive.

For now, dying will just make pawns respawn, but we can make this configurable & enable perma-death (or just switch to perma-death later).

closes #91 
closes #92 