### PR TITLE
Made the player require food to replenish their energy.

### DIFF
--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -24,6 +24,7 @@ namespace osg {
         private TextGameObject numWoodText;
         private TextGameObject numStoneText;
         private TextGameObject numApplesText;
+        private TextGameObject energyText;
 
         public GameObject playerGameObject; // must be set in Unity Editor -- TODO: make this private and set it in the constructor (will require refactoring Player.cs)
         public bool runTests = false;
@@ -54,6 +55,7 @@ namespace osg {
             numWoodText = new TextGameObject("Wood: 0", 20, -Screen.width / 4, 0);
             numStoneText = new TextGameObject("Stone: 0", 20, Screen.width / 4, 0);
             numApplesText = new TextGameObject("Apples: 0", 20, Screen.width / 4, Screen.height / 4);
+            energyText = new TextGameObject("Energy: 100", 20, Screen.width / 4, -Screen.height / 4);
 
             environment.getChunk(0, 0).addEntity(player);
             environment.addEntityId(player.getId());
@@ -79,6 +81,7 @@ namespace osg {
                 numWoodText.updateText("Wood: " + player.getInventory().getNumItems(ItemType.WOOD));
                 numStoneText.updateText("Stone: " + player.getInventory().getNumItems(ItemType.STONE));
                 numApplesText.updateText("Apples: " + player.getInventory().getNumItems(ItemType.APPLE));
+                energyText.updateText("Energy: " + player.getEnergy());
                 status.clearStatusIfExpired();
 
                 // list of positions to generate chunks at
@@ -105,6 +108,14 @@ namespace osg {
                             if (retrievedChunk == null) {
                                 positionsToGenerateChunksAt.Add(pawn.getGameObject().transform.position);
                             }
+                            
+                            if (pawn.getEnergy() <= 0) {
+                                eventProducer.producePawnDeathEvent(pawn.getGameObject().transform.position, pawn);
+                                pawn.setEnergy(100);
+                                pawn.getInventory().clear();
+                                status.update(pawn.getName() + " has died.");
+                                pawn.getGameObject().transform.position = new Vector3(Random.Range(-100, 100), 10, Random.Range(-100, 100));
+                            }
                         }
                     }
                 }
@@ -116,6 +127,13 @@ namespace osg {
             }
             
             player.fixedUpdate();
+            if (player.getEnergy() <= 0) {
+                eventProducer.producePlayerDeathEvent(player.getGameObject().transform.position, player);
+                player.setEnergy(100);
+                player.getInventory().clear();
+                status.update("You died.");
+                player.getGameObject().transform.position = new Vector3(Random.Range(-100, 100), 10, Random.Range(-100, 100));
+            }
             deleteEntitiesMarkedForDeletion();
         }
 

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -151,18 +151,19 @@ namespace osg {
             }
 
             energy -= metabolism;
-            if (energy <= 0) { // TODO: move this to OpenSourceGame.cs?
-                // respawn
-                getInventory().clear();
-                energy = 100.00f;
-                getGameObject().transform.position = new Vector3(Random.Range(-100, 100), 10, Random.Range(-100, 100));
-                // TODO: throw event?
-            }
             nameTag.GetComponent<TextMesh>().text = getName() + " (e=" + energy + ")";
         }
 
         public void setColor(Color color) {
             getGameObject().GetComponent<Renderer>().material.color = color;
+        }
+
+        public float getEnergy() {
+            return energy;
+        }
+
+        public void setEnergy(float energy) {
+            this.energy = energy;
         }
 
         private void gatherResources(Environment environment) {

--- a/src/c#/main/event/EventProducer.cs
+++ b/src/c#/main/event/EventProducer.cs
@@ -51,5 +51,17 @@ namespace osg {
             eventRepository.addEvent(nationDisbandEvent);
             Debug.Log("Produced event: " + nationDisbandEvent);
         }
+
+        public void producePlayerDeathEvent(Vector3 position, Player player) {
+            PlayerDeathEvent playerDeathEvent = new PlayerDeathEvent(position, player);
+            eventRepository.addEvent(playerDeathEvent);
+            Debug.Log("Produced event: " + playerDeathEvent);
+        }
+
+        public void producePawnDeathEvent(Vector3 position, Pawn pawn) {
+            PawnDeathEvent pawnDeathEvent = new PawnDeathEvent(position, pawn);
+            eventRepository.addEvent(pawnDeathEvent);
+            Debug.Log("Produced event: " + pawnDeathEvent);
+        }
     }
 }

--- a/src/c#/main/event/EventType.cs
+++ b/src/c#/main/event/EventType.cs
@@ -9,5 +9,7 @@ namespace osg {
         NationJoin,
         NationLeave,
         PawnSpawn,
+        PawnDeath,
+        PlayerDeath,
     }
 }

--- a/src/c#/main/event/events/PawnDeathEvent.cs
+++ b/src/c#/main/event/events/PawnDeathEvent.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace osg {
+
+    public class PawnDeathEvent : Event {
+
+        private Vector3 position;
+        private Pawn pawn;
+
+        public PawnDeathEvent(Vector3 position, Pawn pawn) : base(EventType.PawnDeath, pawn.getName() + " has died at (" + position.x + ", " + position.y + ", " + position.z + ").") {
+            this.position = position;
+            this.pawn = pawn;
+        }
+
+        public Vector3 getPosition() {
+            return position;
+        }
+
+        public Pawn getPawn() {
+            return pawn;
+        }
+
+        public override string ToString() {
+            return "PawnDeathEvent [position=" + position + ", pawn=" + pawn + ", type=" + getType() + ", description=" + getDescription() + ", date=" + getDate() + "]";
+        }
+    }
+}

--- a/src/c#/main/event/events/PawnDeathEvent.cs.meta
+++ b/src/c#/main/event/events/PawnDeathEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32422bf577ded9a438995f988498d69f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/event/events/PlayerDeathEvent.cs
+++ b/src/c#/main/event/events/PlayerDeathEvent.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace osg {
+
+    public class PlayerDeathEvent : Event {
+
+        private Vector3 position;
+        private Player player;
+
+        public PlayerDeathEvent(Vector3 position, Player player) : base(EventType.PlayerDeath, "Player " + player.getId() + " has died at (" + position.x + ", " + position.y + ", " + position.z + ").") {
+            this.position = position;
+            this.player = player;
+        }
+
+        public Vector3 getPosition() {
+            return position;
+        }
+
+        public Player getPlayer() {
+            return player;
+        }
+
+        public override string ToString() {
+            return "PlayerDeathEvent [position=" + position + ", player=" + player + ", type=" + getType() + ", description=" + getDescription() + ", date=" + getDate() + "]";
+        }
+    }
+}

--- a/src/c#/main/event/events/PlayerDeathEvent.cs.meta
+++ b/src/c#/main/event/events/PlayerDeathEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89cadc060e1a1f54a9073b6164a0632c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/player/Player.cs
+++ b/src/c#/main/player/Player.cs
@@ -16,6 +16,8 @@ namespace osg {
         private NationId nationId = null;
         private Status status = null;
         private bool autoWalk = false;
+        private float energy = 100;
+        private float metabolism = 0.01f;
 
         public Player(GameObject gameObject, int walkSpeed, int runSpeed, Status status) : base(EntityType.PLAYER){
             setGameObject(gameObject);
@@ -65,6 +67,14 @@ namespace osg {
             if (autoWalk) {
                 rigidBody.transform.Translate(Vector3.forward * currentSpeed * Time.deltaTime);
             }
+
+            if (energy < 90 && getInventory().getNumItems(ItemType.APPLE) > 0) {
+                // eat apple
+                getInventory().removeItem(ItemType.APPLE, 1);
+                energy += 10;
+            }
+
+            energy -= metabolism;
         }
 
         private void jump() {
@@ -109,6 +119,14 @@ namespace osg {
 
         public void toggleAutoWalk() {
             autoWalk = !autoWalk;
+        }
+
+        public float getEnergy() {
+            return energy;
+        }
+
+        public void setEnergy(float energy) {
+            this.energy = energy;
         }
     }
 }


### PR DESCRIPTION
The player's energy is now displayed on the screen and ticks down slowly. The player will die if it reaches 0, and must eat food to replenish their energy. The `PlayerDeathEvent` & `PawnDeathEvent` classes have been added.

closes #112 