### PR TITLE
Inter-Pawn Relationships & Behavior Refactoring

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2022-2023 The Fairfield Programming Association Inc.
+Copyright 2022-2023 Preponderous Software & The Fairfield Programming Association Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without limitation in the rights to use, copy, modify, merge, publish, and/ or distribute copies of the Software in an educational or personal context, subject to the following conditions: 
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The following controls are available in the game:
 | `T` | Teleport all living entities to you |
 | `Num Lock` | Toggle auto-walk |
 | `F1` | Spawn a new pawn |
+| `F2` | Generate nearby land |
+| `F3` | Spawn money |
 
 ## Game Systems
 There are a number of systems that will be implemented in the game. These systems will be used to create a rich and engaging gameplay experience. Details can be found in the [Systems Document](./docs/SYSTEMS.md).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following controls are available in the game:
 | `L` | Leave your current nation |
 | `T` | Teleport all living entities to you |
 | `Num Lock` | Toggle auto-walk |
+| `F1` | Spawn a new pawn |
 
 ## Game Systems
 There are a number of systems that will be implemented in the game. These systems will be used to create a rich and engaging gameplay experience. Details can be found in the [Systems Document](./docs/SYSTEMS.md).

--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -260,8 +260,7 @@ namespace osg {
         }
 
         private void createOrJoinNation(Pawn pawn) {
-            // if less than 4 nations, create a new nation
-            if (nationRepository.getNumberOfNations() < 4) {
+            if (nationRepository.getNumberOfNations() <= gameConfig.getNumStartingNations()) {
                 Nation nation = new Nation(NationNameGenerator.generate(), pawn.getId());
                 nationRepository.addNation(nation);
                 pawn.setNationId(nation.getId());

--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -22,7 +22,6 @@ namespace osg {
         private Player player;
 
         private Status status;
-        // private TextGameObject chunkPositionText;
         private TextGameObject numGoldCoinsText;
         private TextGameObject numWoodText;
         private TextGameObject numStoneText;
@@ -66,7 +65,6 @@ namespace osg {
 
             // other UI
             energyText = new TextGameObject("Energy: 100", 20, Screen.width / 4, -Screen.height / 4);
-            // chunkPositionText = new TextGameObject("Chunk: (0, 0)", 20, 0, Screen.height / 4);
 
             // put in very top right corner
             mtpsText = new TextGameObject("0mtps", 20, Screen.width / 4, Screen.height / 4);
@@ -78,18 +76,15 @@ namespace osg {
 
         // Per-frame updates
         public void Update() {
-            tickCounter.increment(); // should this be in FixedUpdate()?
-
             handleCommands();
-
             player.update();
         }
 
         // Fixed updates
         public void FixedUpdate() {
+            tickCounter.increment();
             worldGenerator.update();
             checkIfPlayerIsFallingIntoVoid();
-            // chunkPositionText.updateText("Chunk: (" + worldGenerator.getCurrentChunkX() + ", " + worldGenerator.getCurrentChunkZ() + ")");
             numGoldCoinsText.updateText("Gold Coins: " + player.getInventory().getNumItems(ItemType.GOLD_COIN));
             numWoodText.updateText("Wood: " + player.getInventory().getNumItems(ItemType.WOOD));
             numStoneText.updateText("Stone: " + player.getInventory().getNumItems(ItemType.STONE));

--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -240,18 +240,13 @@ namespace osg {
                 SpawnPawnCommand command = new SpawnPawnCommand(environment, eventProducer);
                 command.execute(player);
             }
-            else if (Input.GetKeyDown(KeyCode.F2)) { // TODO: move this to a separate class
-                Vector3 playerPosition = player.getGameObject().transform.position;
-                Chunk playerChunk = environment.getChunkAtPosition(playerPosition);
-                if (playerChunk != null) {
-                    Vector3 chunkPosition = playerChunk.getGameObject().transform.position;
-                    for (int x = -50; x < 51; x++) {
-                        for (int z = -50; z < 51; z++) {
-                            Vector3 position = new Vector3(chunkPosition.x + x * 10, 0, chunkPosition.z + z * 10);
-                            worldGenerator.generateChunkAtPosition(position);
-                        }
-                    }
-                }
+            else if (Input.GetKeyDown(KeyCode.F2)) {
+                GenerateLandCommand command = new GenerateLandCommand(environment, worldGenerator);
+                command.execute(player);
+            }
+            else if (Input.GetKeyDown(KeyCode.F3)) {
+                SpawnMoneyCommand command = new SpawnMoneyCommand();
+                command.execute(player);
             }
         }
 

--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -22,7 +22,7 @@ namespace osg {
         private Player player;
 
         private Status status;
-        private TextGameObject chunkPositionText;
+        // private TextGameObject chunkPositionText;
         private TextGameObject numGoldCoinsText;
         private TextGameObject numWoodText;
         private TextGameObject numStoneText;
@@ -65,7 +65,7 @@ namespace osg {
 
             // other UI
             energyText = new TextGameObject("Energy: 100", 20, Screen.width / 4, -Screen.height / 4);
-            chunkPositionText = new TextGameObject("Chunk: (0, 0)", 20, 0, Screen.height / 4);
+            // chunkPositionText = new TextGameObject("Chunk: (0, 0)", 20, 0, Screen.height / 4);
 
             environment.getChunk(0, 0).addEntity(player);
             environment.addEntityId(player.getId());
@@ -86,7 +86,7 @@ namespace osg {
             if (tickCounter.shouldUpdate()) {
                 worldGenerator.update();
                 checkIfPlayerIsFallingIntoVoid();
-                chunkPositionText.updateText("Chunk: (" + worldGenerator.getCurrentChunkX() + ", " + worldGenerator.getCurrentChunkZ() + ")");
+                // chunkPositionText.updateText("Chunk: (" + worldGenerator.getCurrentChunkX() + ", " + worldGenerator.getCurrentChunkZ() + ")");
                 numGoldCoinsText.updateText("Gold Coins: " + player.getInventory().getNumItems(ItemType.GOLD_COIN));
                 numWoodText.updateText("Wood: " + player.getInventory().getNumItems(ItemType.WOOD));
                 numStoneText.updateText("Stone: " + player.getInventory().getNumItems(ItemType.STONE));

--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -52,14 +52,20 @@ namespace osg {
             eventProducer = new EventProducer(eventRepository);
             environment = new Environment(gameConfig.getChunkSize(), gameConfig.getLocationScale());
             worldGenerator = new WorldGenerator(environment, player, eventProducer);
-            chunkPositionText = new TextGameObject("Chunk: (0, 0)", 20, 0, Screen.height / 4);
             nationRepository = new NationRepository();
             pawnBehaviorExecutor = new PawnBehaviorExecutor(environment, nationRepository, eventProducer);
-            numGoldCoinsText = new TextGameObject("Gold Coins: 0", 20, -Screen.width / 4, Screen.height / 4);
-            numWoodText = new TextGameObject("Wood: 0", 20, -Screen.width / 4, 0);
-            numStoneText = new TextGameObject("Stone: 0", 20, Screen.width / 4, 0);
-            numApplesText = new TextGameObject("Apples: 0", 20, Screen.width / 4, Screen.height / 4);
+
+            // resources UI
+            int resourcesX = -Screen.width / 4;
+            int resourcesY = -Screen.height / 4;
+            numGoldCoinsText = new TextGameObject("Gold Coins: 0", 20, resourcesX, resourcesY);
+            numWoodText = new TextGameObject("Wood: 0", 20, resourcesX, resourcesY - 20);
+            numStoneText = new TextGameObject("Stone: 0", 20, resourcesX, resourcesY - 40);
+            numApplesText = new TextGameObject("Apples: 0", 20, resourcesX, resourcesY - 60);
+
+            // other UI
             energyText = new TextGameObject("Energy: 100", 20, Screen.width / 4, -Screen.height / 4);
+            chunkPositionText = new TextGameObject("Chunk: (0, 0)", 20, 0, Screen.height / 4);
 
             environment.getChunk(0, 0).addEntity(player);
             environment.addEntityId(player.getId());

--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -28,6 +28,7 @@ namespace osg {
         private TextGameObject numStoneText;
         private TextGameObject numApplesText;
         private TextGameObject energyText;
+        private TextGameObject mtpsText;
 
         public GameObject playerGameObject; // must be set in Unity Editor -- TODO: make this private and set it in the constructor (will require refactoring Player.cs)
         public bool runTests = false;
@@ -67,6 +68,9 @@ namespace osg {
             energyText = new TextGameObject("Energy: 100", 20, Screen.width / 4, -Screen.height / 4);
             // chunkPositionText = new TextGameObject("Chunk: (0, 0)", 20, 0, Screen.height / 4);
 
+            // put in very top right corner
+            mtpsText = new TextGameObject("0mtps", 20, Screen.width / 4, Screen.height / 4);
+
             environment.getChunk(0, 0).addEntity(player);
             environment.addEntityId(player.getId());
             status.update("Press N to create a nation.");
@@ -92,6 +96,7 @@ namespace osg {
                 numStoneText.updateText("Stone: " + player.getInventory().getNumItems(ItemType.STONE));
                 numApplesText.updateText("Apples: " + player.getInventory().getNumItems(ItemType.APPLE));
                 energyText.updateText("Energy: " + player.getEnergy());
+                mtpsText.updateText(tickCounter.getMtps() + "mtps");
                 status.clearStatusIfExpired();
 
                 // list of positions to generate chunks at
@@ -186,7 +191,7 @@ namespace osg {
                 InteractCommand command = new InteractCommand(environment, nationRepository, eventProducer);
                 command.execute(player);
             }
-            else if (Input.GetKeyDown(KeyCode.Alpha1)) {
+            else if (Input.GetKeyDown(KeyCode.F1)) {
                 SpawnPawnCommand command = new SpawnPawnCommand(environment, eventProducer);
                 command.execute(player);
             }

--- a/src/c#/main/behavior/BehaviorType.cs
+++ b/src/c#/main/behavior/BehaviorType.cs
@@ -5,5 +5,6 @@ namespace osg {
         GATHER_RESOURCES,
         SELL_RESOURCES,
         WANDER,
+        PURCHASE_FOOD,
     }
 }

--- a/src/c#/main/behavior/PawnBehaviorExecutor.cs
+++ b/src/c#/main/behavior/PawnBehaviorExecutor.cs
@@ -167,8 +167,8 @@ namespace osg {
         }
 
         private void executeWanderBehavior(Pawn pawn) {
-            // 90% chance to skip
-            if (Random.Range(0f, 1f) < 0.9f) {
+            // 95% chance to skip
+            if (Random.Range(0, 100) < 95) {
                 return;
             }
             Vector3 currentPosition = pawn.getPosition();

--- a/src/c#/main/behavior/PawnBehaviorExecutor.cs
+++ b/src/c#/main/behavior/PawnBehaviorExecutor.cs
@@ -1,0 +1,153 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace osg {
+
+    /**
+     * A class that handles pawn actions.
+     */
+    public class PawnBehaviorExecutor {
+        private Environment environment;
+        private NationRepository nationRepository;
+        private EventProducer eventProducer;
+
+        public PawnBehaviorExecutor(Environment environment, NationRepository nationRepository, EventProducer eventProducer) {
+            this.environment = environment;
+            this.nationRepository = nationRepository;
+            this.eventProducer = eventProducer;
+        }
+
+        public void executeBehavior(Pawn pawn, BehaviorType behaviorType) {
+            switch (behaviorType) {
+                case BehaviorType.GATHER_RESOURCES:
+                    executeGatherResourcesBehavior(pawn);
+                    break;
+                case BehaviorType.SELL_RESOURCES:
+                    executeSellResourcesBehavior(pawn);
+                    break;
+                case BehaviorType.WANDER:
+                    executeWanderBehavior(pawn);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void executeGatherResourcesBehavior(Pawn pawn) {
+            if (!pawn.hasTargetEntity()) {
+                // select nearest tree or rock
+                Entity nearestTree = environment.getNearestTree(pawn.getPosition());
+                Entity nearestRock = environment.getNearestRock(pawn.getPosition());
+                if (nearestTree != null && nearestRock != null) {
+                    if (Vector3.Distance(pawn.getPosition(), nearestTree.getPosition()) < Vector3.Distance(pawn.getPosition(), nearestRock.getPosition())) {
+                        pawn.setTargetEntity(nearestTree);
+                    } else {
+                        pawn.setTargetEntity(nearestRock);
+                    }
+                } else if (nearestTree != null) {
+                    pawn.setTargetEntity(nearestTree);
+                } else if (nearestRock != null) {
+                    pawn.setTargetEntity(nearestRock);
+                }
+            }
+
+            Entity targetEntity = pawn.getTargetEntity();
+            EntityType targetEntityType = targetEntity.getType();
+            
+            if (pawn.isAtTargetEntity()) {
+                // gather
+                if (targetEntity.getType() == EntityType.TREE || targetEntityType == EntityType.ROCK) {
+                    targetEntity.markForDeletion();
+                    pawn.getInventory().transferContentsOfInventory(targetEntity.getInventory());
+                    pawn.setTargetEntity(null);
+                }
+                else {
+                    Debug.LogWarning("Pawn " + pawn + " is at target entity " + targetEntity + " but it is not a tree or rock.");
+                    pawn.setTargetEntity(null);
+                }
+            }
+            else {
+                // move towards target entity
+                pawn.moveTowardsTargetEntity();
+            }
+        }
+
+        private void executeSellResourcesBehavior(Pawn pawn) {
+            if (!pawn.hasTargetEntity()) {
+                // target nation leader
+                Nation nation = nationRepository.getNation(pawn.getNationId());
+                if (nation != null) {
+                    EntityId nationLeaderId = nation.getLeaderId();
+                    Entity nationLeader = environment.getEntity(nationLeaderId);
+                    if (nationLeader != null) {
+                        pawn.setTargetEntity(nationLeader);
+                    }
+                }
+            }
+            else if (pawn.isAtTargetEntity()) {
+                Inventory pawnInventory = pawn.getInventory();
+
+                int numWood = pawnInventory.getNumItems(ItemType.WOOD);
+                int numStone = pawnInventory.getNumItems(ItemType.STONE);
+                int numApples = pawnInventory.getNumItems(ItemType.APPLE);
+
+                Entity targetEntity = pawn.getTargetEntity();
+                EntityType targetEntityType = targetEntity.getType();
+                Inventory targetInventory = null;
+                if (targetEntityType == EntityType.PAWN) {
+                    targetInventory = ((Pawn)targetEntity).getInventory();
+                }
+                else if (targetEntityType == EntityType.PLAYER) {
+                    targetInventory = ((Player)targetEntity).getInventory();
+                }
+                else {
+                    Debug.LogWarning("Pawn " + pawn + " has target entity " + targetEntity + " but it is not a pawn or player.");
+                    pawn.setTargetEntity(null);
+                    return;
+                }
+
+                int woodPrice = 2;
+                int stonePrice = 3;
+                int applePrice = 1;
+                int cost = numWood * woodPrice + numStone * stonePrice + numApples * applePrice;
+                if (targetInventory.getNumItems(ItemType.GOLD_COIN) >= cost) {
+                    targetInventory.removeItem(ItemType.GOLD_COIN, cost);
+                    targetInventory.addItem(ItemType.WOOD, numWood);
+                    targetInventory.addItem(ItemType.STONE, numStone);
+                    targetInventory.addItem(ItemType.APPLE, numApples);
+                    pawnInventory.removeItem(ItemType.WOOD, numWood);
+                    pawnInventory.removeItem(ItemType.STONE, numStone);
+                    pawnInventory.removeItem(ItemType.APPLE, numApples);
+
+                    int increase = Random.Range(1, 3);
+                    if (pawn.getRelationships().ContainsKey(targetEntity.getId())) {
+                        pawn.getRelationships()[targetEntity.getId()] += increase;
+                    }
+                    else {
+                        pawn.getRelationships().Add(targetEntity.getId(), increase);
+                    }
+                    
+                    eventProducer.producePawnRelationshipIncreaseEvent(pawn, targetEntity, increase);
+                }
+                else {
+                    Debug.LogWarning("Pawn " + pawn + " has target entity " + targetEntity + " but it does not have enough coins.");
+                    pawn.setTargetEntity(null);
+                }
+            }
+            else {
+                // move towards target entity
+                pawn.moveTowardsTargetEntity();
+            }
+        }
+
+        private void executeWanderBehavior(Pawn pawn) {
+            // 90% chance to skip
+            if (Random.Range(0f, 1f) < 0.9f) {
+                return;
+            }
+            Vector3 currentPosition = pawn.getPosition();
+            Vector3 targetPosition = currentPosition + new Vector3(Random.Range(-1f, 1f), 0, Random.Range(-1f, 1f));
+            pawn.getGameObject().GetComponent<Rigidbody>().velocity = (targetPosition - currentPosition).normalized * pawn.getSpeed();
+        }
+    }
+}

--- a/src/c#/main/behavior/PawnBehaviorExecutor.cs
+++ b/src/c#/main/behavior/PawnBehaviorExecutor.cs
@@ -121,6 +121,7 @@ namespace osg {
                     pawnInventory.removeItem(ItemType.WOOD, numWood);
                     pawnInventory.removeItem(ItemType.STONE, numStone);
                     pawnInventory.removeItem(ItemType.APPLE, numApples);
+                    pawnInventory.addItem(ItemType.GOLD_COIN, cost);
 
                     int increase = Random.Range(1, 3);
                     if (pawn.getRelationships().ContainsKey(targetEntity.getId())) {
@@ -185,13 +186,15 @@ namespace osg {
 
                 int applePrice = 1;
                 int cost = applePrice;
-                if (targetInventory.getNumItems(ItemType.GOLD_COIN) >= cost) {
-                    targetInventory.removeItem(ItemType.GOLD_COIN, cost);
-                    targetInventory.addItem(ItemType.APPLE, 1);
-                    pawn.getInventory().addItem(ItemType.APPLE, 1);
+                Inventory pawnInventory = pawn.getInventory();
+                if (pawnInventory.getNumItems(ItemType.GOLD_COIN) >= cost) {
+                    pawnInventory.removeItem(ItemType.GOLD_COIN, cost);
+                    targetInventory.removeItem(ItemType.APPLE, 1);
+                    pawnInventory.addItem(ItemType.APPLE, 1);
+                    
                 }
                 else {
-                    Debug.LogWarning("Pawn " + pawn + " has target entity " + targetEntity + " but it does not have enough coins.");
+                    Debug.LogWarning("Pawn " + pawn.getName() + " has target entity " + targetEntity.getId() + " but it does not have enough coins.");
                     pawn.setTargetEntity(null);
                 }
             }

--- a/src/c#/main/behavior/PawnBehaviorExecutor.cs
+++ b/src/c#/main/behavior/PawnBehaviorExecutor.cs
@@ -38,7 +38,7 @@ namespace osg {
         }
 
         private void executeGatherResourcesBehavior(Pawn pawn) {
-            if (!pawn.hasTargetEntity()) {
+            if (!pawn.hasTargetEntity() || (pawn.getTargetEntity().getType() != EntityType.TREE && pawn.getTargetEntity().getType() != EntityType.ROCK)) {
                 // select nearest tree or rock
                 Entity nearestTree = environment.getNearestTree(pawn.getPosition());
                 Entity nearestRock = environment.getNearestRock(pawn.getPosition());

--- a/src/c#/main/behavior/PawnBehaviorExecutor.cs.meta
+++ b/src/c#/main/behavior/PawnBehaviorExecutor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d920406239b59ad4e84e11190e4276ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/command/miscellaneous/GenerateLandCommand.cs
+++ b/src/c#/main/command/miscellaneous/GenerateLandCommand.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+namespace osg {
+
+    public class GenerateLandCommand {
+        private Environment environment;
+        private WorldGenerator worldGenerator;
+
+        public GenerateLandCommand(Environment environment, WorldGenerator worldGenerator) {
+            this.environment = environment;
+            this.worldGenerator = worldGenerator;
+        }
+
+        public void execute(Player player) {
+            Vector3 playerPosition = player.getGameObject().transform.position;
+            Chunk playerChunk = environment.getChunkAtPosition(playerPosition);
+            if (playerChunk != null) {
+                Vector3 chunkPosition = playerChunk.getGameObject().transform.position;
+                int numChunksGenerated = 0;
+                for (int x = -50; x < 51; x++) {
+                    for (int z = -50; z < 51; z++) {
+                        int chunkSize = environment.getChunkSize();
+                        Vector3 position = new Vector3(chunkPosition.x + x * chunkSize, 0, chunkPosition.z + z * chunkSize);
+                        bool generatedNewChunk = worldGenerator.generateChunkAtPosition(position);
+                        if (generatedNewChunk) {
+                            numChunksGenerated++;
+                        }
+                    }
+                }
+                player.getStatus().update("Generated " + numChunksGenerated + " chunks.");
+            }
+        }
+    }
+}

--- a/src/c#/main/command/miscellaneous/GenerateLandCommand.cs.meta
+++ b/src/c#/main/command/miscellaneous/GenerateLandCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce962006507f7304196cde6636854793
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/command/miscellaneous/SpawnMoneyCommand.cs
+++ b/src/c#/main/command/miscellaneous/SpawnMoneyCommand.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace osg {
+
+    public class SpawnMoneyCommand {
+
+        public void execute(Player player) {
+            player.getInventory().addItem(ItemType.GOLD_COIN, 100);
+            player.getStatus().update("Spawned 100 gold coins.");
+        }
+    }
+}

--- a/src/c#/main/command/miscellaneous/SpawnMoneyCommand.cs.meta
+++ b/src/c#/main/command/miscellaneous/SpawnMoneyCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb03508c3f69c314d9441aeb4c5aee73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/command/miscellaneous/SpawnPawnCommand.cs
+++ b/src/c#/main/command/miscellaneous/SpawnPawnCommand.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace osg {
+
+    public class SpawnPawnCommand {
+        private Environment environment;
+        private EventProducer eventProducer;
+
+        public SpawnPawnCommand(Environment environment, EventProducer eventProducer) {
+            this.environment = environment;
+            this.eventProducer = eventProducer;
+        }
+
+        public void execute(Player player) {
+            Vector3 position = player.getGameObject().transform.position;
+            Pawn pawn = new Pawn(position, PawnNameGenerator.generate());
+            eventProducer.producePawnSpawnEvent(position, pawn);
+
+            Chunk playerChunk = environment.getChunkAtPosition(position);
+            playerChunk.addEntity(pawn);
+            environment.addEntityId(pawn.getId());
+            pawn.getGameObject().transform.parent = playerChunk.getGameObject().transform;
+        }
+    }
+}

--- a/src/c#/main/command/miscellaneous/SpawnPawnCommand.cs.meta
+++ b/src/c#/main/command/miscellaneous/SpawnPawnCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4899db480cb53d142bd7c7630b3e76a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/command/miscellaneous/TeleportAllPawns.cs
+++ b/src/c#/main/command/miscellaneous/TeleportAllPawns.cs
@@ -13,6 +13,7 @@ namespace osg {
                     if (entity.getType() == EntityType.PAWN) {
                         Pawn pawn = (Pawn)entity;
                         pawn.getGameObject().transform.position = player.getGameObject().transform.position;
+                        pawn.setTargetEntity(null);
                     }
                 }
             }

--- a/src/c#/main/config/GameConfig.cs
+++ b/src/c#/main/config/GameConfig.cs
@@ -3,7 +3,6 @@ namespace osg {
     class GameConfig {
         private int chunkSize;
         private int locationScale;
-        private int updateInterval;
         private int statusExpirationTicks;
         private int playerWalkSpeed;
         private int playerRunSpeed;
@@ -11,7 +10,6 @@ namespace osg {
         public GameConfig() {
             chunkSize = 9;
             locationScale = 9;
-            updateInterval = 10;
             statusExpirationTicks = 500;
             playerWalkSpeed = 20;
             playerRunSpeed = 50;
@@ -23,10 +21,6 @@ namespace osg {
 
         public int getLocationScale() {
             return locationScale;
-        }
-
-        public int getUpdateInterval() {
-            return updateInterval;
         }
 
         public int getStatusExpirationTicks() {

--- a/src/c#/main/config/GameConfig.cs
+++ b/src/c#/main/config/GameConfig.cs
@@ -7,6 +7,7 @@ namespace osg {
         private int playerWalkSpeed;
         private int playerRunSpeed;
         private bool respawnPawns;
+        private int numStartingNations;
 
         public GameConfig() {
             chunkSize = 9;
@@ -15,6 +16,7 @@ namespace osg {
             playerWalkSpeed = 20;
             playerRunSpeed = 50;
             respawnPawns = false;
+            numStartingNations = 2;
         }
 
         public int getChunkSize() {
@@ -39,6 +41,10 @@ namespace osg {
 
         public bool getRespawnPawns() {
             return respawnPawns;
+        }
+
+        public int getNumStartingNations() {
+            return numStartingNations;
         }
     }
 }

--- a/src/c#/main/config/GameConfig.cs
+++ b/src/c#/main/config/GameConfig.cs
@@ -6,6 +6,7 @@ namespace osg {
         private int statusExpirationTicks;
         private int playerWalkSpeed;
         private int playerRunSpeed;
+        private bool respawnPawns;
 
         public GameConfig() {
             chunkSize = 9;
@@ -13,6 +14,7 @@ namespace osg {
             statusExpirationTicks = 500;
             playerWalkSpeed = 20;
             playerRunSpeed = 50;
+            respawnPawns = false;
         }
 
         public int getChunkSize() {
@@ -33,6 +35,10 @@ namespace osg {
 
         public int getPlayerRunSpeed() {
             return playerRunSpeed;
+        }
+
+        public bool getRespawnPawns() {
+            return respawnPawns;
         }
     }
 }

--- a/src/c#/main/entity/Entity.cs
+++ b/src/c#/main/entity/Entity.cs
@@ -54,6 +54,9 @@ namespace osg {
         public void setInventory(Inventory inventory) {
             this.inventory = inventory;
         }
-    }
 
+        public Vector3 getPosition() {
+            return getGameObject().transform.position;
+        }
+    }
 }

--- a/src/c#/main/entity/PawnNameGenerator.cs
+++ b/src/c#/main/entity/PawnNameGenerator.cs
@@ -85,6 +85,11 @@ namespace osg {
                 return generate();
             }
             generated.Add(fullName);
+
+            if (generated.Count == names.Length * familyNames.Length) {
+                generated.Clear();
+            }
+
             return fullName;
         }
     }

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -18,7 +18,7 @@ namespace osg {
 
         private GameObject nameTag;
         private float energy = 100.00f;
-        private float metabolism = Random.Range(0.001f, 0.010f);
+        private float metabolism = Random.Range(0.01f, 0.10f);
 
         // map of entity id to integer representing relationship strength
         private Dictionary<EntityId, int> relationships = new Dictionary<EntityId, int>();

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -161,7 +161,7 @@ namespace osg {
                         currentBehaviorType = BehaviorType.PURCHASE_FOOD;
                         return;
                     }
-                }
+                } // TODO: fix this so this doesn't happen all the time
 
                 currentBehaviorType = BehaviorType.GATHER_RESOURCES;
                 return;

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -67,11 +67,9 @@ namespace osg {
 
         public void moveTowardsTargetEntity() {
             if (targetEntity == null) {
-                Debug.LogWarning("target entity is null in moveTowardsTargetEntity()");
                 return;
             }
             if (targetEntity.isMarkedForDeletion()) {
-                Debug.LogWarning("target entity is marked for deletion in moveTowardsTargetEntity()");
                 setTargetEntity(null);
                 return;
             }
@@ -89,11 +87,9 @@ namespace osg {
 
         public bool isAtTargetEntity() {
             if (targetEntity == null) {
-                Debug.LogWarning("target entity is null in isAtTargetEntity()");
                 return false;
             }
             if (targetEntity.isMarkedForDeletion()) {
-                Debug.LogWarning("target entity is marked for deletion in isAtTargetEntity()");
                 setTargetEntity(null);
                 return false;
             }

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -157,7 +157,7 @@ namespace osg {
                         currentBehaviorType = BehaviorType.PURCHASE_FOOD;
                         return;
                     }
-                } // TODO: fix this so this doesn't happen all the time
+                }
 
                 currentBehaviorType = BehaviorType.GATHER_RESOURCES;
                 return;
@@ -206,5 +206,40 @@ namespace osg {
         public float getMetabolism() {
             return metabolism;
         }
+
+        public void increaseRelationship(Entity entity, int amount) {
+            if (entity == null) {
+                Debug.LogError("entity is null in increaseRelationship()");
+                return;
+            }
+            if (entity.getId() == getId()) {
+                Debug.LogError("entity is self in increaseRelationship()");
+                return;
+            }
+            if (getRelationships().ContainsKey(entity.getId())) {
+                getRelationships()[entity.getId()] += amount;
+            }
+            else {
+                getRelationships().Add(entity.getId(), amount);
+            }
+        }
+
+        public void decreaseRelationship(Entity entity, int amount) {
+            if (entity == null) {
+                Debug.LogError("entity is null in decreaseRelationship()");
+                return;
+            }
+            if (entity.getId() == getId()) {
+                Debug.LogError("entity is self in decreaseRelationship()");
+                return;
+            }
+            if (getRelationships().ContainsKey(entity.getId())) {
+                getRelationships()[entity.getId()] -= amount;
+            }
+            else {
+                getRelationships().Add(entity.getId(), -amount);
+            }
+        }
+
     }
 }

--- a/src/c#/main/entity/entities/Pawn.cs
+++ b/src/c#/main/entity/entities/Pawn.cs
@@ -18,7 +18,7 @@ namespace osg {
 
         private GameObject nameTag;
         private float energy = 100.00f;
-        private float metabolism = Random.Range(0.01f, 0.05f);
+        private float metabolism = Random.Range(0.001f, 0.010f);
 
         // map of entity id to integer representing relationship strength
         private Dictionary<EntityId, int> relationships = new Dictionary<EntityId, int>();
@@ -151,23 +151,37 @@ namespace osg {
 
         // The current behavior type should only be changed in computeBehaviorType()
         public void computeBehaviorType(Environment environment, NationRepository nationRepository) {
-            // if hungry
+
             if (energy < 80 && getInventory().getNumItems(ItemType.APPLE) == 0) {
+                // if nation leader has apples, purchase apples from leader
+                if (getNationId() != null) {
+                    Nation nation1 = nationRepository.getNation(getNationId());
+                    Entity nationLeader = environment.getEntity(nation1.getLeaderId());
+                    if (nationLeader.getInventory().getNumItems(ItemType.APPLE) > 0 && getInventory().getNumItems(ItemType.GOLD_COIN) >= 1) {
+                        currentBehaviorType = BehaviorType.PURCHASE_FOOD;
+                        return;
+                    }
+                }
+
                 currentBehaviorType = BehaviorType.GATHER_RESOURCES;
                 return;
             }
+
             if (getNationId() == null) {
                 currentBehaviorType = BehaviorType.WANDER;
                 return;
             }
+
             Nation nation = nationRepository.getNation(getNationId());
+
             NationRole role = nation.getRole(getId());
             if (role == NationRole.LEADER) {
                 currentBehaviorType = BehaviorType.WANDER;
                 return;
             }
             else if (role == NationRole.CITIZEN) {
-                if (getInventory().getNumItems(ItemType.WOOD) >= targetNumWood && getInventory().getNumItems(ItemType.STONE) >= targetNumStone) {
+                // if pawn has at least 1 of each resource, sell resources
+                if (getInventory().getNumItems(ItemType.WOOD) >= 1 && getInventory().getNumItems(ItemType.STONE) >= 1 && getInventory().getNumItems(ItemType.APPLE) >= 1) {
                     Entity nationLeader = environment.getEntity(nation.getLeaderId());
                     int numWood = getInventory().getNumItems(ItemType.WOOD);
                     int numStone = getInventory().getNumItems(ItemType.STONE);

--- a/src/c#/main/entity/entities/TreeEntity.cs
+++ b/src/c#/main/entity/entities/TreeEntity.cs
@@ -34,8 +34,8 @@ namespace osg {
             
             setGameObject(gameObject);
 
-            getInventory().addItem(ItemType.WOOD, UnityEngine.Random.Range(2, 4));
-            getInventory().addItem(ItemType.APPLE, UnityEngine.Random.Range(1, 3));
+            getInventory().addItem(ItemType.WOOD, UnityEngine.Random.Range(3, 6));
+            getInventory().addItem(ItemType.APPLE, UnityEngine.Random.Range(2, 4));
         }
 
         public override void destroyGameObject() {

--- a/src/c#/main/entity/entities/TreeEntity.cs
+++ b/src/c#/main/entity/entities/TreeEntity.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace osg {
@@ -33,8 +34,8 @@ namespace osg {
             
             setGameObject(gameObject);
 
-            getInventory().addItem(ItemType.WOOD, height * 2);
-            getInventory().addItem(ItemType.APPLE, height / 2);
+            getInventory().addItem(ItemType.WOOD, UnityEngine.Random.Range(2, 4));
+            getInventory().addItem(ItemType.APPLE, UnityEngine.Random.Range(1, 3));
         }
 
         public override void destroyGameObject() {

--- a/src/c#/main/event/EventProducer.cs
+++ b/src/c#/main/event/EventProducer.cs
@@ -63,5 +63,11 @@ namespace osg {
             eventRepository.addEvent(pawnDeathEvent);
             Debug.Log("Produced event: " + pawnDeathEvent);
         }
+
+        public void producePawnRelationshipIncreaseEvent(Pawn pawn1, Entity entity2, int increase) {
+            PawnRelationshipIncreaseEvent pawnRelationshipIncreaseEvent = new PawnRelationshipIncreaseEvent(pawn1, entity2, increase);
+            eventRepository.addEvent(pawnRelationshipIncreaseEvent);
+            Debug.Log("Produced event: " + pawnRelationshipIncreaseEvent);
+        }
     }
 }

--- a/src/c#/main/event/EventType.cs
+++ b/src/c#/main/event/EventType.cs
@@ -11,5 +11,6 @@ namespace osg {
         PawnSpawn,
         PawnDeath,
         PlayerDeath,
+        PawnRelationshipIncrease
     }
 }

--- a/src/c#/main/event/events/PawnRelationshipIncreaseEvent.cs
+++ b/src/c#/main/event/events/PawnRelationshipIncreaseEvent.cs
@@ -1,0 +1,33 @@
+namespace osg {
+
+    /**
+     * An event that is fired when a relationship between two pawns increases.
+     */
+    public class PawnRelationshipIncreaseEvent : Event {
+        private Pawn pawn1;
+        private Entity entity2;
+        private int increase;
+
+        public PawnRelationshipIncreaseEvent(Pawn pawn1, Entity entity2, int increase) : base(EventType.PawnRelationshipIncrease, "The relationship between " + pawn1.getName() + " and " + entity2.getId() + "has increased by " + increase + ".") {
+            this.pawn1 = pawn1;
+            this.entity2 = entity2;
+            this.increase = increase;
+        }
+
+        public Pawn getPawn1() {
+            return pawn1;
+        }
+
+        public Entity getEntity2() {
+            return entity2;
+        }
+
+        public int getIncrease() {
+            return increase;
+        }
+        
+        public override string ToString() {
+            return "PawnRelationshipIncreaseEvent[" + pawn1.getName() + ", " + entity2.getId() + ", " + increase + "]";
+        }
+    }
+}

--- a/src/c#/main/event/events/PawnRelationshipIncreaseEvent.cs.meta
+++ b/src/c#/main/event/events/PawnRelationshipIncreaseEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34ef5a3e7c490e14c8d69988b4d334b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/c#/main/nation/Nation.cs
+++ b/src/c#/main/nation/Nation.cs
@@ -70,5 +70,9 @@ namespace osg {
             int randomIndex = Random.Range(0, members.Count);
             return members[randomIndex];
         }
+
+        public EntityId getOldestMemberId() {
+            return members[0];
+        }
     }
 }

--- a/src/c#/main/tick/TickCounter.cs
+++ b/src/c#/main/tick/TickCounter.cs
@@ -4,17 +4,12 @@ namespace osg {
 
     public class TickCounter {
         private int tick = 0;
-        private int updateInterval = 10;
         
         // measured ticks per second
         private int mtps = 0;
         
         // last time tick was updated
         private DateTime lastTickUpdate = DateTime.Now;
-
-        public TickCounter(int updateInterval) {
-            this.updateInterval = updateInterval;
-        }
 
         public int getTick() {
             return tick;
@@ -28,10 +23,6 @@ namespace osg {
                 tick = 0;
                 lastTickUpdate = DateTime.Now;
             }
-        }
-
-        public bool shouldUpdate() {
-            return tick % updateInterval == 0;
         }
 
         public int getMtps() {

--- a/src/c#/main/tick/TickCounter.cs
+++ b/src/c#/main/tick/TickCounter.cs
@@ -1,9 +1,16 @@
+using System;
+
 namespace osg {
 
     public class TickCounter {
         private int tick = 0;
         private int updateInterval = 10;
-        private int lastUpdateTick = 0;
+        
+        // measured ticks per second
+        private int mtps = 0;
+        
+        // last time tick was updated
+        private DateTime lastTickUpdate = DateTime.Now;
 
         public TickCounter(int updateInterval) {
             this.updateInterval = updateInterval;
@@ -12,21 +19,23 @@ namespace osg {
         public int getTick() {
             return tick;
         }
-        
-        public int getLastUpdateTick() {
-            return lastUpdateTick;
-        }
 
         public void increment() {
             tick++;
+
+            if (DateTime.Now - lastTickUpdate >= TimeSpan.FromSeconds(1)) {
+                mtps = tick;
+                tick = 0;
+                lastTickUpdate = DateTime.Now;
+            }
         }
 
         public bool shouldUpdate() {
-            if (tick - lastUpdateTick >= updateInterval) {
-                lastUpdateTick = tick;
-                return true;
-            }
-            return false;
+            return tick % updateInterval == 0;
+        }
+
+        public int getMtps() {
+            return mtps;
         }
     }
 }

--- a/src/c#/main/world/WorldGenerator.cs
+++ b/src/c#/main/world/WorldGenerator.cs
@@ -54,12 +54,13 @@ namespace osg {
             generateChunkIfNotExistent(chunkX + 1, chunkZ + 1);
         }
 
-        private void generateChunkIfNotExistent(int chunkX, int chunkZ) {
-            // check if chunk exists
+        private bool generateChunkIfNotExistent(int chunkX, int chunkZ) {
             Chunk chunk = environment.getChunk(chunkX, chunkZ);
             if (chunk == null) {
                 createNewChunkAt(chunkX, chunkZ);
+                return true;
             }
+            return false;
         }
 
         /**
@@ -155,7 +156,7 @@ namespace osg {
             }
         }
 
-        public void generateChunkAtPosition(Vector3 position) {
+        public bool generateChunkAtPosition(Vector3 position) {
             int lengthOfChunk = chunkSize * locationScale;
 
             int chunkX = 0;
@@ -172,7 +173,7 @@ namespace osg {
                 chunkZ = (int) (position.z / lengthOfChunk) - 1;
             }
 
-            generateChunkIfNotExistent(chunkX, chunkZ);
+            return generateChunkIfNotExistent(chunkX, chunkZ);
         }
 
         public void generateSurroundingChunksAtPosition(Vector3 position) {

--- a/src/c#/tests/config/TestGameConfig.cs
+++ b/src/c#/tests/config/TestGameConfig.cs
@@ -17,7 +17,6 @@ namespace osgtests {
             // check
             Debug.Assert(config.getChunkSize() == 9);
             Debug.Assert(config.getLocationScale() == 9);
-            Debug.Assert(config.getUpdateInterval() == 10);
             Debug.Assert(config.getStatusExpirationTicks() == 500);
             Debug.Assert(config.getPlayerWalkSpeed() == 20);
             Debug.Assert(config.getPlayerRunSpeed() == 50);

--- a/src/c#/tests/tick/TestTickCounter.cs
+++ b/src/c#/tests/tick/TestTickCounter.cs
@@ -9,42 +9,25 @@ namespace osgtests {
         public static void runTests() {
             testInstantiation();
             testIncrement();
-            testShouldUpdate();
         }
 
         public static void testInstantiation() {
             // run
-            int updateInterval = 10;
-            TickCounter tickCounter = new TickCounter(updateInterval);
+            TickCounter tickCounter = new TickCounter();
 
             // check
             Debug.Assert(tickCounter.getTick() == 0);
-            Debug.Assert(tickCounter.shouldUpdate() == false);
         }
 
         public static void testIncrement() {
             // prepare
-            int updateInterval = 10;
-            TickCounter tickCounter = new TickCounter(updateInterval);
+            TickCounter tickCounter = new TickCounter();
 
             // run
             tickCounter.increment();
 
             // check
             Debug.Assert(tickCounter.getTick() == 1);
-        }
-
-        public static void testShouldUpdate() {
-            // prepare
-            int updateInterval = 2;
-            TickCounter tickCounter = new TickCounter(updateInterval);
-
-            // run
-            tickCounter.increment();
-            tickCounter.increment();
-
-            // check
-            Debug.Assert(tickCounter.shouldUpdate() == true);
         }
         
     }

--- a/src/c#/tests/tick/TestTickCounter.cs
+++ b/src/c#/tests/tick/TestTickCounter.cs
@@ -10,7 +10,6 @@ namespace osgtests {
             testInstantiation();
             testIncrement();
             testShouldUpdate();
-            testGetLastUpdateTick();
         }
 
         public static void testInstantiation() {
@@ -20,7 +19,6 @@ namespace osgtests {
 
             // check
             Debug.Assert(tickCounter.getTick() == 0);
-            Debug.Assert(tickCounter.getLastUpdateTick() == 0);
             Debug.Assert(tickCounter.shouldUpdate() == false);
         }
 
@@ -47,21 +45,6 @@ namespace osgtests {
 
             // check
             Debug.Assert(tickCounter.shouldUpdate() == true);
-        }
-
-        public static void testGetLastUpdateTick() {
-            // prepare
-            int updateInterval = 2;
-            TickCounter tickCounter = new TickCounter(updateInterval);
-
-            // run
-            for (int i = 0; i < 3; i++) {
-                tickCounter.increment();
-                tickCounter.shouldUpdate();
-            }
-
-            // check
-            Debug.Assert(tickCounter.getLastUpdateTick() == 2);
         }
         
     }


### PR DESCRIPTION
## Description
Pawns now have the ability to keep track of their perceptions of other pawns. Upon peforming a successful trade, their relationship with the target entity will increase. This will be utilized in further development.

Behavior code has been refactored and moved to the PawnBehaviorExecutor class.

## Additional Changes
- The resource UI text has been rearranged for better organization, placing them close to each other in the bottom left of the screen.
- Pawns will now purchase food from their nation leader if they have no apples and sufficient money.
- To allow for permadeath, a new configuration option called respawnPawns has been added.
- Pawns will now trade less resources at a time, preventing a lot of deadlock.
- Added F1 command to spawn a new pawn.
- Added F2 command to generate a bunch of land around the player. (for debug testing)
- Added F3 command to give the player 100 gold coins (for debug testing)
- The `numStartingNations` config option has been added.
- 'Preponderous Software' has been added back into the copyright line of the `LICENSE.md` file.

## Related Issues
closes #109 
closes #126 