### PR TITLE
Random Stall Selection

### DIFF
--- a/src/c#/main/OpenSourceGame.cs
+++ b/src/c#/main/OpenSourceGame.cs
@@ -154,8 +154,8 @@ namespace osg {
 
                             if (player.getNationId() != null) {
                                 Nation nation = nationRepository.getNation(player.getNationId());
-                                
-                                if (nation.getLeaderId() == pawn.getId()) {
+                                NationRole role = nation.getRole(pawn.getId());
+                                if (role == NationRole.LEADER) {
                                     // transfer leadership to another pawn
                                     if (nation.getNumberOfMembers() > 0) {
                                         nation.setLeaderId(nation.getOldestMemberId());
@@ -187,7 +187,7 @@ namespace osg {
                                         player.getStatus().update(nation.getName() + " has been disbanded.");
                                     }
                                 }
-                                else if (nation.getRole(pawn.getId()) == NationRole.MERCHANT) {
+                                else if (role == NationRole.MERCHANT) {
                                     // remove stall ownership
                                     foreach (EntityId settlementId in nation.getSettlements()) {
                                         Settlement settlement = (Settlement)entityRepository.getEntity(settlementId);

--- a/src/c#/main/behavior/PawnBehaviorCalculator.cs
+++ b/src/c#/main/behavior/PawnBehaviorCalculator.cs
@@ -92,7 +92,7 @@ namespace osg {
                 else {
 
                     // if pawn has an abundance of resources, sell them
-                    if (pawn.getInventory().containsAbundanceOfResources()) {
+                    if (pawn.getInventory().containsAbundanceOfResources() && homeMarket.getTotalCoins() > 10) {
                         return BehaviorType.SELL_RESOURCES;
                     }
 
@@ -113,7 +113,7 @@ namespace osg {
 
                 Market market = homeSettlement.getMarket();
                 Stall stall = market.getStall(pawn.getId());
-                if (stall.getInventory().hasItem(ItemType.COIN)) {
+                if (stall.getInventory().hasItem(ItemType.COIN) && stall.getInventory().getNumItems(ItemType.COIN) >= Stall.COIN_COST_TO_PURCHASE * 2) {
                     return BehaviorType.COLLECT_PROFIT_FROM_STALL;
                 }
                 

--- a/src/c#/main/market/Market.cs
+++ b/src/c#/main/market/Market.cs
@@ -89,11 +89,14 @@ namespace osg {
             return totalNumItemsSold;
         }
 
-        public bool purchaseFood(Pawn pawn) {
+        public EntityId purchaseFood(Pawn pawn) {
             return buyItem(pawn, ItemType.APPLE, 1);
         }
 
-        public bool buyItem(Pawn pawn, ItemType itemType, int quantity) {
+        /**
+        * @return the id of the stall owner, or null if purchase failed
+        */
+        public EntityId buyItem(Pawn pawn, ItemType itemType, int quantity) {
             int cost = ItemCostCalculator.calculateCostBasedOnSupply(itemType, this);
             List<Stall> stallsToBuyFrom = new List<Stall>();
             foreach(Stall stall in stalls) {
@@ -115,7 +118,7 @@ namespace osg {
                 stallsToBuyFrom.Add(stall);
             }
             if (stallsToBuyFrom.Count == 0) {
-                return false;
+                return null;
             }
 
             int randomStallIndex = Random.Range(0, stallsToBuyFrom.Count);
@@ -132,10 +135,13 @@ namespace osg {
             totalNumItemsBought += quantity;
 
             UnityEngine.Debug.Log("Pawn " + pawn.getName() + " bought " + quantity + " " + itemType + " from " + stallToBuyFrom.getOwnerId() + " for " + cost * quantity + " coins");
-            return true;
+            return stallToBuyFrom.getOwnerId();
         }
 
-        public void sellResources(Pawn pawn) {
+        /**
+        * @return the id of the stall owner, or null if purchase failed
+        */
+        public EntityId sellResources(Pawn pawn) {
             List<Stall> stallsToSellTo = new List<Stall>();
             foreach(Stall stall in stalls) {
                 if (stall.getOwnerId() == null) {
@@ -163,7 +169,7 @@ namespace osg {
                 }
             }
             if (stallsToSellTo.Count == 0) {
-                return;
+                return null;
             }
 
             int randomStallIndex = Random.Range(0, stallsToSellTo.Count);
@@ -194,8 +200,8 @@ namespace osg {
 
                 totalNumItemsSold++;
                 UnityEngine.Debug.Log("Pawn " + pawn.getName() + " sold 1 " + itemType + " to " + stallToSellTo.getOwnerId() + " for " + cost + " coins");
-                return;
             }
+            return stallToSellTo.getOwnerId();
         }
 
         public int getQuantityAvailable(ItemType itemType) {
@@ -210,6 +216,10 @@ namespace osg {
                 quantityAvailable += stall.getInventory().getNumItems(itemType);
             }
             return quantityAvailable;
+        }
+
+        public int getTotalCoins() {
+            return getQuantityAvailable(ItemType.COIN);
         }
     }
 }


### PR DESCRIPTION
## Changes
Made pawns select stalls randomly rather than sequentially going through each stall when buying/selling items at a market.

## Additional Changes
- Increased relationship between pawns when trading.
- Made pawns take into account whether the market had any coins before attempting to sell goods.

closes #151 
closes #150 