### PR TITLE
Accounted for pawns in settlements when handling deaths.

### DIFF
--- a/src/c#/main/behavior/PawnBehaviorCalculator.cs
+++ b/src/c#/main/behavior/PawnBehaviorCalculator.cs
@@ -36,6 +36,8 @@ namespace osg {
         }
 
         private BehaviorType computeBehaviorTypeInSettlement(Pawn pawn) {
+            int chanceToExitSettlement = 1;
+
             EntityId currentSettlementId = pawn.getCurrentSettlementId();
             if (currentSettlementId == null) {
                 return BehaviorType.NONE;
@@ -72,7 +74,7 @@ namespace osg {
                 }
                 else {
                     // 10% chance to exit settlement
-                    if (Random.Range(0, 100) < 10) {
+                    if (Random.Range(0, 100) < chanceToExitSettlement) {
                         return BehaviorType.EXIT_SETTLEMENT;
                     }
                     else {
@@ -93,7 +95,7 @@ namespace osg {
                     }
 
                     // 10% chance to exit settlement
-                    if (Random.Range(0, 100) < 10) {
+                    if (Random.Range(0, 100) < chanceToExitSettlement) {
                         return BehaviorType.EXIT_SETTLEMENT;
                     }
                     else {
@@ -111,7 +113,7 @@ namespace osg {
                     return BehaviorType.COLLECT_PROFIT_FROM_STALL;
                 }
                 
-                if (Random.Range(0, 100) < 10) {
+                if (Random.Range(0, 100) < chanceToExitSettlement) {
                     return BehaviorType.EXIT_SETTLEMENT;
                 }
                 else {

--- a/src/c#/main/behavior/PawnBehaviorExecutor.cs
+++ b/src/c#/main/behavior/PawnBehaviorExecutor.cs
@@ -190,8 +190,6 @@ namespace osg {
                 Debug.LogWarning("Pawn " + pawn.getName() + " tried to purchase food from settlement market " + settlement + " but there was not enough food.");
             }
             else {
-                Debug.Log("[PBE DEBUG] Pawn " + pawn.getName() + " purchased food from settlement market " + settlement + ".");
-
                 // increase relationship with stall owner
                 Entity stallOwner = entityRepository.getEntity(stallOwnerId);
                 if (stallOwner is Pawn) {
@@ -497,13 +495,11 @@ namespace osg {
         private void increaseRelationship(Pawn pawn, Pawn otherPawn, int amount) {
             pawn.increaseRelationship(otherPawn, amount);
             otherPawn.increaseRelationship(pawn, amount);
-            Debug.Log("[PBE DEBUG] Pawn " + pawn.getName() + " now has a relationship of " + pawn.getRelationships()[otherPawn.getId()] + " with stall owner " + otherPawn.getName() + ".");
         }
 
         private void increaseRelationship(Pawn pawn, Player player, int amount) {
             pawn.increaseRelationship(player, amount);
             player.increaseRelationship(pawn, amount);
-            Debug.Log("[PBE DEBUG] Pawn " + pawn.getName() + " now has a relationship of " + pawn.getRelationships()[player.getId()] + " with player " + player.getId() + ".");
             player.getStatus().update("Relationship with " + pawn.getName() + " is now " + player.getRelationships()[pawn.getId()] + ".");
         }
     }

--- a/src/c#/main/command/miscellaneous/GenerateLandCommand.cs
+++ b/src/c#/main/command/miscellaneous/GenerateLandCommand.cs
@@ -5,13 +5,22 @@ namespace osg {
     public class GenerateLandCommand {
         private Environment environment;
         private WorldGenerator worldGenerator;
+        private GameConfig gameConfig;
 
-        public GenerateLandCommand(Environment environment, WorldGenerator worldGenerator) {
+        public GenerateLandCommand(Environment environment, WorldGenerator worldGenerator, GameConfig gameConfig) {
             this.environment = environment;
             this.worldGenerator = worldGenerator;
+            this.gameConfig = gameConfig;
         }
 
         public void execute(Player player) {
+            int maxNumChunks = gameConfig.getMaxNumChunks();
+            int numChunks = environment.getNumChunks();
+            if (numChunks >= maxNumChunks) {
+                player.getStatus().update("Max number of chunks reached.");
+                return;
+            }
+
             int numChunksGenerated = 0;
             Vector3 playerPosition = player.getGameObject().transform.position;
             Chunk chunk = environment.getChunkAtPosition(playerPosition);

--- a/src/c#/main/event/EventProducer.cs
+++ b/src/c#/main/event/EventProducer.cs
@@ -52,14 +52,14 @@ namespace osg {
             Debug.Log("Produced event: " + nationDisbandEvent);
         }
 
-        public void producePlayerDeathEvent(Vector3 position, Player player) {
-            PlayerDeathEvent playerDeathEvent = new PlayerDeathEvent(position, player);
+        public void producePlayerDeathEvent(Player player) {
+            PlayerDeathEvent playerDeathEvent = new PlayerDeathEvent(player);
             eventRepository.addEvent(playerDeathEvent);
             Debug.Log("Produced event: " + playerDeathEvent);
         }
 
-        public void producePawnDeathEvent(Vector3 position, Pawn pawn) {
-            PawnDeathEvent pawnDeathEvent = new PawnDeathEvent(position, pawn);
+        public void producePawnDeathEvent(Pawn pawn) {
+            PawnDeathEvent pawnDeathEvent = new PawnDeathEvent(pawn);
             eventRepository.addEvent(pawnDeathEvent);
             Debug.Log("Produced event: " + pawnDeathEvent);
         }

--- a/src/c#/main/event/events/PawnDeathEvent.cs
+++ b/src/c#/main/event/events/PawnDeathEvent.cs
@@ -3,25 +3,14 @@ using UnityEngine;
 namespace osg {
 
     public class PawnDeathEvent : Event {
-
-        private Vector3 position;
         private Pawn pawn;
 
-        public PawnDeathEvent(Vector3 position, Pawn pawn) : base(EventType.PawnDeath, pawn.getName() + " has died at (" + position.x + ", " + position.y + ", " + position.z + ").") {
-            this.position = position;
+        public PawnDeathEvent(Pawn pawn) : base(EventType.PawnDeath, pawn.getName() + " has died.") {
             this.pawn = pawn;
-        }
-
-        public Vector3 getPosition() {
-            return position;
         }
 
         public Pawn getPawn() {
             return pawn;
-        }
-
-        public override string ToString() {
-            return "PawnDeathEvent [position=" + position + ", pawn=" + pawn + ", type=" + getType() + ", description=" + getDescription() + ", date=" + getDate() + "]";
         }
     }
 }

--- a/src/c#/main/event/events/PlayerDeathEvent.cs
+++ b/src/c#/main/event/events/PlayerDeathEvent.cs
@@ -7,21 +7,12 @@ namespace osg {
         private Vector3 position;
         private Player player;
 
-        public PlayerDeathEvent(Vector3 position, Player player) : base(EventType.PlayerDeath, "Player " + player.getId() + " has died at (" + position.x + ", " + position.y + ", " + position.z + ").") {
-            this.position = position;
+        public PlayerDeathEvent(Player player) : base(EventType.PlayerDeath, "Player " + player.getId() + " has died.") {
             this.player = player;
-        }
-
-        public Vector3 getPosition() {
-            return position;
         }
 
         public Player getPlayer() {
             return player;
-        }
-
-        public override string ToString() {
-            return "PlayerDeathEvent [position=" + position + ", player=" + player + ", type=" + getType() + ", description=" + getDescription() + ", date=" + getDate() + "]";
         }
     }
 }


### PR DESCRIPTION
We were skipping the pawn death handling for pawns in settlements, resulting in some errors.

Additionally, the player energy UI was re-positioned & chunk generation was limited based on the max num chunks config option.